### PR TITLE
linux では nvim を build する

### DIFF
--- a/startup/linux/run_once_01_install_packages.tmpl
+++ b/startup/linux/run_once_01_install_packages.tmpl
@@ -18,7 +18,6 @@ apt install -y \
   git \
   gh \
   neofetch \
-  neovim \
   nnn \
   ripgrep \
   thefuck \

--- a/startup/linux/run_once_01_install_packages.tmpl
+++ b/startup/linux/run_once_01_install_packages.tmpl
@@ -4,6 +4,10 @@
 
 {{ if eq .chezmoi.osRelease.id "debian" }}
 
+#############################
+# install cmd
+#############################
+
 apt update
 apt install -y \
   bat \
@@ -11,6 +15,7 @@ apt install -y \
   exa \
   fd-find \
   fzf \
+  git \
   gh \
   neofetch \
   neovim \
@@ -21,6 +26,10 @@ apt install -y \
   tmux \
   tmuxinator \
   wget
+
+#############################
+# dl by github release
+#############################
 
 function dl_github_pkg() {
   GITHUB_USER=$1
@@ -39,9 +48,11 @@ function dl_github_pkg() {
 KERNEL=$(uname -s | tr '[:upper:]' '[:lower:]')
 MACHINE=$(uname -m | tr '[:upper:]' '[:lower:]')
 
-# dl_github_pkg "neovim" "neovim" "v0.9.4" "nvim-linux64.tar.gz" "nvim-linux64/bin/nvim"
-
 dl_github_pkg "extrawurst" "gitui" "v0.24.3" "gitui-${KERNEL}-${MACHINE}.tar.gz" "gitui"
+
+#############################
+# dl by curl
+#############################
 
 # starship
 curl -sS https://starship.rs/install.sh | sh -s -- --yes
@@ -50,7 +61,16 @@ curl -sS https://starship.rs/install.sh | sh -s -- --yes
 curl --proto '=https' -fLsS https://rossmacarthur.github.io/install/crate.sh \
     | bash -s -- --repo rossmacarthur/sheldon --to /usr/local/bin
 
-source ~/.zprofile
+#############################
+# nvim build
+# apt で入る nvim が古すぎる
+#############################
+
+git clone https://github.com/neovim/neovim --depth=1
+cd neovim
+apt install -y libtool autoconf automake make cmake libncurses5-dev g++ gettext
+make CMAKE_BUILD_TYPE=RelWithDebInfo
+make install
 
 {{ end }}
 


### PR DESCRIPTION
apt で入る linux が古すぎる。
しかし、 docker 内の debian で github release nvim を利用しようとすると cpu アーキテクチャが異なるためエラーが出る。

そのため、 nvim を直接いれて build する