### PR TITLE
user 設定を別ファイルに分離させる

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -6,3 +6,5 @@
 !.config/gh/config.yml
 
 bin/executable_chezmoi
+
+.gitconfig_user

--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -2,9 +2,8 @@
 [core]
 	editor = vim
 	pager = delta
-[user]
-	name = ganyariya
-	email = ganariya2525@gmail.com
+	# 日本語を正常に表示させる
+	quotepath = false
 [color]
 	ui = auto
 [alias]
@@ -17,3 +16,13 @@
 	conflictstyle = diff3
 [diff]
 	colorMoved = default
+# lfs のデフォルト設定
+[filter "lfs"]
+    clean = git-lfs clean -- %f
+    smudge = git-lfs smudge -- %f
+    process = git-lfs filter-process
+    required = true
+
+# 個人と会社で email が異なるため user は分離する
+[include]
+	path = ~/.gitconfig_user


### PR DESCRIPTION
個人と会社で、 git で利用する email が異なる。
しかし、dotfiles で .gitconfig を管理しているため email がコンフリクトしてしまう

そのため、 .gitconfig から email 設定を切り離し、 そのそも dotfiles にいれないようにする

利用するときは .gitconfig_user ファイルをローカル pc で作成して、そのファイルに記載する
