### PR TITLE
:sparkles: Add go path (from install)

### DIFF
--- a/dot_zprofile
+++ b/dot_zprofile
@@ -11,6 +11,7 @@
 # export PATH
 ################################################################################
 export PATH=$PATH:$HOME/bin/
+export PATH=$PATH:$GOPATH/bin/
 export PATH=$HOME/.nodebrew/current/bin:$PATH
 
 ################################################################################


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `$GOPATH/bin/` to the `PATH` environment variable, enabling easier access to Go binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->