### PR TITLE
:sparkles: File の有無によって環境変数を切り分ける

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -8,3 +8,6 @@
 bin/executable_chezmoi
 
 .gitconfig_user
+
+# 各利用環境ごとにファイルを作成する
+.config/zsh/zsh_neovim_github_copilot

--- a/dot_zprofile
+++ b/dot_zprofile
@@ -20,6 +20,15 @@ export PATH=$HOME/.nodebrew/current/bin:$PATH
 export GOPATH=$HOME/go
 
 ################################################################################
+# export NEOVIM_GITHUB_COPILOT environment variable
+# 個人と会社で github copilot が使えるかが異なる
+# そのため、ファイルの有無をもとに環境変数を切り替えて neovim で使う ai assistant を変更する
+################################################################################
+if [[ -f  ~/.config/zsh/zsh_neovim_github_copilot ]] && [[ $(cat ~/.config/zsh/zsh_neovim_github_copilot) == "1" ]] ; then
+  export NEOVIM_GITHUB_COPILOT=1
+fi
+
+################################################################################
 # Homebrew setup
 ################################################################################
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for ignoring specific configuration files in Chezmoi, enhancing user control over environment setups.
  - Introduced a conditional export of the `NEOVIM_GITHUB_COPILOT` environment variable, allowing users to enable or disable GitHub Copilot integration in Neovim based on a configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->