### PR TITLE
:sparkles: 一時的に chezmoi startup script をとめる

### DIFF
--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -26,3 +26,9 @@
 # 個人と会社で email が異なるため user は分離する
 [include]
 	path = ~/.gitconfig_user
+[credential "https://github.com"]
+	helper = 
+	helper = !/opt/homebrew/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper = 
+	helper = !/opt/homebrew/bin/gh auth git-credential

--- a/startup/mac/run_once_01_install_brew.sh.tmpl
+++ b/startup/mac/run_once_01_install_brew.sh.tmpl
@@ -2,6 +2,9 @@
 
 {{ if eq .chezmoi.os "darwin" }}
 
+# 一時的に startup を止める
+exit 0
+
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 brew bundle --file="$HOME/.Brewfile"

--- a/startup/mac/run_once_02_setup_mac_defaults_system.tmpl
+++ b/startup/mac/run_once_02_setup_mac_defaults_system.tmpl
@@ -2,7 +2,8 @@
 
 {{ if eq .chezmoi.os "darwin" }}
 
-ls
+# 一時的に startup を止める
+exit 0
 
 ########################
 # Dock

--- a/startup/mac/run_once_03_setup_true_color.sh.tmpl
+++ b/startup/mac/run_once_03_setup_true_color.sh.tmpl
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 {{ if eq .chezmoi.os "darwin" }}
+# 一時的に startup を止める
+exit 0
 
 infocmp tmux-256color > ~/tmux-256color.info
 tic -xe tmux-256color ~/tmux-256color.info


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Git credential management by integrating GitHub CLI for authentication, streamlining access to repositories and gists.
- **Chores**
	- Introduced temporary script modifications in macOS setup scripts to prevent further execution, likely for debugging or maintenance purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->