### PR TITLE
feature/nvim cursor jump

### DIFF
--- a/dot_config/nvim/lua/ganyariya/core/keymaps.lua
+++ b/dot_config/nvim/lua/ganyariya/core/keymaps.lua
@@ -1,7 +1,7 @@
 local keymap = vim.keymap
 
 local opts = function(desc)
-	return { noremap = true, silent = true, desc = desc }
+  return { noremap = true, silent = true, desc = desc }
 end
 
 vim.g.mapleader = " "
@@ -69,18 +69,21 @@ keymap.set("n", "<Leader>bw", "<Cmd>wall<CR>", opts("Save all modified buffers")
 keymap.set("n", "<Leader>b`", "<Cmd>b#<CR>", opts("Go to last buffer"))
 
 ----------------------------
--- Scroll Cycle
+--- Scroll cursor position
 ----------------------------
-local scroll_state = 1
-keymap.set("n", "zz", function()
-	if scroll_state == 1 then
-		vim.cmd("normal! zz")
-		scroll_state = 2
-	elseif scroll_state == 2 then
-		vim.cmd("normal! zt")
-		scroll_state = 3
-	elseif scroll_state == 3 then
-		vim.cmd("normal! zb")
-		scroll_state = 1
-	end
-end, { noremap = true, silent = true, desc = "Cycle scroll position (center/top/bottom)" })
+_G.scroll_cycle = _G.scroll_cycle or {
+  state = 1,
+}
+
+keymap.set("n", "zp", function()
+  if _G.scroll_cycle.state == 1 then
+    vim.cmd("normal! zz")
+    _G.scroll_cycle.state = 2
+  elseif _G.scroll_cycle.state == 2 then
+    vim.cmd("normal! zt")
+    _G.scroll_cycle.state = 3
+  elseif _G.scroll_cycle.state == 3 then
+    vim.cmd("normal! zb")
+    _G.scroll_cycle.state = 1
+  end
+end, { noremap = true, silent = false, desc = "Cycle scroll position (center/top/bottom)" })

--- a/dot_config/nvim/lua/ganyariya/core/keymaps.lua
+++ b/dot_config/nvim/lua/ganyariya/core/keymaps.lua
@@ -1,7 +1,7 @@
 local keymap = vim.keymap
 
 local opts = function(desc)
-  return { noremap = true, silent = true, desc = desc }
+	return { noremap = true, silent = true, desc = desc }
 end
 
 vim.g.mapleader = " "
@@ -67,3 +67,20 @@ keymap.set("n", "<Leader>bo", "<Cmd>%bdelete|e#|bdelete#<CR>", opts("Delete all 
 keymap.set("n", "<Leader>bw", "<Cmd>wall<CR>", opts("Save all modified buffers"))
 
 keymap.set("n", "<Leader>b`", "<Cmd>b#<CR>", opts("Go to last buffer"))
+
+----------------------------
+-- Scroll Cycle
+----------------------------
+local scroll_state = 1
+keymap.set("n", "zz", function()
+	if scroll_state == 1 then
+		vim.cmd("normal! zz")
+		scroll_state = 2
+	elseif scroll_state == 2 then
+		vim.cmd("normal! zt")
+		scroll_state = 3
+	elseif scroll_state == 3 then
+		vim.cmd("normal! zb")
+		scroll_state = 1
+	end
+end, { noremap = true, silent = true, desc = "Cycle scroll position (center/top/bottom)" })

--- a/dot_config/nvim/lua/ganyariya/plugins/flash.lua
+++ b/dot_config/nvim/lua/ganyariya/plugins/flash.lua
@@ -1,8 +1,8 @@
 return {
-  "folke/flash.nvim",
-  event = "VeryLazy",
-  ---@type Flash.Config
-  opts = {},
+	"folke/flash.nvim",
+	event = "VeryLazy",
+	---@type Flash.Config
+	opts = {},
   -- stylua: ignore
   keys = {
     { "s", mode = { "n", "x", "o" }, function() require("flash").jump() end, desc = "Flash" },


### PR DESCRIPTION
- **chezmoi: zz で vim スクロールが行えるようにする**
- **add scrooll**
https://zenn.dev/vim_jp/articles/67ec77641af3f2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new key mapping that enables users to effortlessly cycle the cursor's scroll position between centered, top, and bottom views in the editor. This improvement simplifies navigation and makes tracking the current line in long documents easier, providing an enhanced workflow and a more dynamic scrolling experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->